### PR TITLE
fix: app jar path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN mkdir /app && \
     addgroup -S appuser && \
     adduser -S -D -H -s /bin/false -G appuser appuser
 
-COPY target/app.jar /app/app.jar
+# source path is set according to the Github workflow to build the image
+# when running locally, the jar-file produced by the Maven build needs to be renamed, and copied into the root dir!
+COPY app.jar /app/app.jar
 
 RUN chown -R appuser:appuser /app
 


### PR DESCRIPTION
The Github workflow to build the Docker image downloads the jar file into the root directory, so use that path in the Dockerfile. This is slightly less convenient for local development (now need to move the jar file), but it fixes the pipeline. Alternatively, the pipeline could have been adapted to put the jar file somewhere else.